### PR TITLE
Fix compiler warnings; taskENTER_CRITICAL() is deprecated

### DIFF
--- a/src/gos/gos_freertos.h
+++ b/src/gos/gos_freertos.h
@@ -85,8 +85,8 @@ extern "C" {
 #define gfxMillisecondsToTicks(ms)	((systemticks_t)((ms) / portTICK_PERIOD_MS))
 #define gfxTicksToMilliseconds(ticks)	(ticks * portTICK_PERIOD_MS)
 
-#define gfxSystemLock()				taskENTER_CRITICAL(&lockMux)
-#define gfxSystemUnlock()			taskEXIT_CRITICAL(&lockMux)
+#define gfxSystemLock()				portENTER_CRITICAL(&lockMux)
+#define gfxSystemUnlock()			portEXIT_CRITICAL(&lockMux)
 
 void gfxMutexInit(gfxMutex* s);
 #define gfxMutexDestroy(pmutex)		vSemaphoreDelete(*(pmutex))


### PR DESCRIPTION
replaced by portENTER_CRITICAL()